### PR TITLE
Add flexible LLM benchmarking script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # llm-benchmark
 
-This repository contains a small script to measure the approximate tokens per minute (TPM) for a few open models: **Llama 3.1 8B**, **Qwen 2.5**, and **Gemma 2B**.
+This repository contains a small script to measure the approximate tokens per minute
+(TPM) for a few open models. By default it benchmarks **Llama 3.1 8B**,
+**Qwen 2.5**, and **Gemma 2B**, but any additional model from Hugging Face
+can be supplied at the command line.
 
-The script relies on the [transformers](https://github.com/huggingface/transformers) library and PyTorch. Ensure these dependencies are installed before running the benchmark. Each model will be loaded using `device_map="auto"` to utilize available GPU or CPU resources.
+The script relies on the
+[transformers](https://github.com/huggingface/transformers) library and
+PyTorch. Ensure these dependencies are installed before running the
+benchmark. Each model is loaded with `device_map="auto"` to utilize
+available GPU or CPU resources.
 
 ## Usage
 
@@ -10,10 +17,19 @@ The script relies on the [transformers](https://github.com/huggingface/transform
 python benchmark.py
 ```
 
-Optional arguments allow customizing the prompt and number of generated tokens:
+Optional arguments allow customizing the prompt, number of generated tokens,
+timed runs, and warm‑up steps:
 
 ```bash
-python benchmark.py --prompt "Tell me a story" --tokens 256
+python benchmark.py --prompt "Tell me a story" --tokens 256 --runs 3 --warmup 1
 ```
 
-The script prints the measured TPM for each model or a failure message if the model cannot be loaded.
+Additional models can be benchmarked using `--model`, which accepts
+`label=repo_id` pairs and may be provided multiple times:
+
+```bash
+python benchmark.py --model mytiny=sshleifer/tiny-gpt2 --tokens 32
+```
+
+The script prints the measured TPM for each model or a failure message
+if the model cannot be loaded.

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,26 +1,53 @@
 import argparse
+import gc
 import time
+from typing import Dict, Iterable
 
+import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 
-def measure_model(model_name: str, prompt: str, num_tokens: int = 128) -> float:
-    """Load a model and measure tokens per minute for a short generation."""
-    tokenizer = AutoTokenizer.from_pretrained(model_name)
-    model = AutoModelForCausalLM.from_pretrained(model_name, device_map="auto")
+def measure_model(
+    model_name: str,
+    prompt: str,
+    num_tokens: int = 128,
+    runs: int = 1,
+    warmup: int = 1,
+) -> float:
+    """Load a model and measure tokens per minute for short generations."""
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_name, trust_remote_code=True
+    )
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name, device_map="auto", trust_remote_code=True
+    )
+    model.eval()
 
     inputs = tokenizer(prompt, return_tensors="pt").to(model.device)
 
-    start = time.perf_counter()
-    output = model.generate(**inputs, max_new_tokens=num_tokens)
-    end = time.perf_counter()
+    with torch.inference_mode():
+        for _ in range(warmup):
+            model.generate(**inputs, max_new_tokens=1)
 
-    generated = output.shape[-1] - inputs.input_ids.shape[-1]
-    seconds = end - start
-    if seconds == 0:
+    total_generated = 0
+    total_time = 0.0
+
+    with torch.inference_mode():
+        for _ in range(runs):
+            start = time.perf_counter()
+            output = model.generate(**inputs, max_new_tokens=num_tokens)
+            end = time.perf_counter()
+            total_generated += output.shape[-1] - inputs.input_ids.shape[-1]
+            total_time += end - start
+
+    del model, tokenizer
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    if total_time == 0:
         return 0.0
-    tokens_per_minute = (generated / seconds) * 60
-    return tokens_per_minute
+    return (total_generated / total_time) * 60
 
 
 def main():
@@ -36,17 +63,53 @@ def main():
         default=128,
         help="Number of tokens to generate for measurement.",
     )
+    parser.add_argument(
+        "--runs",
+        type=int,
+        default=1,
+        help="Number of timed runs per model.",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=1,
+        help="Number of warm-up runs before timing.",
+    )
+    parser.add_argument(
+        "--model",
+        action="append",
+        metavar="LABEL=REPO",
+        help=(
+            "Model repository to benchmark. "
+            "Format: label=repo_id. Can be specified multiple times."
+        ),
+    )
     args = parser.parse_args()
 
-    models = {
-        "Llama3-8B": "meta-llama/Meta-Llama-3.1-8B",
-        "Qwen-2.5": "Qwen/Qwen2.5",
-        "Gemma-2B": "google/gemma-2b",
-    }
+    default_models = [
+        "Llama3-8B=meta-llama/Meta-Llama-3.1-8B",
+        "Qwen-2.5=Qwen/Qwen2.5",
+        "Gemma-2B=google/gemma-2b",
+    ]
+    model_entries: Iterable[str] = args.model or default_models
+    models: Dict[str, str] = {}
+    for entry in model_entries:
+        if "=" in entry:
+            label, repo = entry.split("=", 1)
+        else:
+            repo = entry
+            label = repo.split("/")[-1]
+        models[label] = repo
 
     for label, repo in models.items():
         try:
-            tpm = measure_model(repo, args.prompt, args.tokens)
+            tpm = measure_model(
+                repo,
+                args.prompt,
+                args.tokens,
+                runs=args.runs,
+                warmup=args.warmup,
+            )
             print(f"{label}: {tpm:.2f} tokens/minute")
         except Exception as e:
             print(f"{label}: failed to benchmark ({e})")


### PR DESCRIPTION
## Summary
- make benchmarking function more accurate by running warmup and multiple timed runs
- expose CLI options for runs, warmup, and custom model IDs
- document usage and model configuration examples

## Testing
- `python -m pip install --quiet torch==2.1.2 --index-url https://download.pytorch.org/whl/cpu` *(failed: Could not find a version that satisfies the requirement torch==2.1.2 (ProxyError: Cannot connect to proxy, OSError: Tunnel connection failed: 403 Forbidden))*
- `python benchmark.py --model mytiny=sshleifer/tiny-gpt2 --tokens 4 --runs 1 --warmup 0` *(failed: ModuleNotFoundError: No module named 'torch')*
- `python -m py_compile benchmark.py`


------
https://chatgpt.com/codex/tasks/task_e_689b212070388330a5dfd5e7275923f1